### PR TITLE
perf: Use getUserGroupsIds instead of getUserGroups

### DIFF
--- a/lib/Service/UserService.php
+++ b/lib/Service/UserService.php
@@ -487,14 +487,10 @@ class UserService {
      * Get group IDs for a user
      *
      * @param string $userId User ID
-     * @return array Array of group IDs
+     * @return list<string> Array of group IDs
      */
     private function getGroupsForUser(string $userId): array {
-        $groups = [];
-        foreach ($this->groupManager->getUserGroups($this->userManager->get($userId)) as $group) {
-            $groups[] = $group->getGID();
-        }
-        return $groups;
+		return $this->groupManager->getUserGroupIds($this->userManager->get($userId));
     }
 
     /**


### PR DESCRIPTION
Several time faster when there is multiple group backends enabled



## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
